### PR TITLE
Added validation for duplicate addresses

### DIFF
--- a/app/errors/address_already_taken_error.rb
+++ b/app/errors/address_already_taken_error.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Errors
+  class AddressAlreadyTakenError < BaseError # rubocop:disable Style/Documentation
+    def message
+      'The address is already in use by another client'
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require './app/errors/base_error'
+
 Dir[File.join('./', 'app', '**', '*.rb')].each do |file|
   require file
 end

--- a/spec/lib/wire_guard/server_spec.rb
+++ b/spec/lib/wire_guard/server_spec.rb
@@ -589,5 +589,66 @@ RSpec.describe WireGuard::Server do
         expect(WireGuard::ServerConfigUpdater).to have_received(:update)
       end
     end
+
+    context 'when the specified address is already in use by another client' do
+      let(:id) { '1' }
+      let(:config_params) do
+        {
+          'address' => '10.8.0.3',
+          'private_key' => 'a',
+          'public_key' => 'b',
+          'enable' => false
+        }
+      end
+      let(:expected_result) do
+        {
+          'server' => {
+            'private_key' => '6Mlqg+1Umojm7a4VvgIi+YMp4oPrWNnZ5HLRFu4my2w=',
+            'public_key' => 'uygGKpQt7gOwrP+bqkiXytafHiM+XqFGc0jtZVJ5bnw=',
+            'address' => '10.8.0.1'
+          },
+          'configs' => {
+            'last_id' => 3,
+            '1' => {
+              'id' => 1,
+              'address' => '10.8.0.200',
+              'private_key' => 'a',
+              'public_key' => 'b',
+              'preshared_key' => '3UzAMA6mLIGjHOImShNb5tWlkwxsha8LZZP7dm49meQ=',
+              'enable' => false,
+              'data' => {
+                'lol' => 'kek'
+              }
+            },
+            '2' => {
+              'id' => 2,
+              'address' => '10.8.0.3',
+              'private_key' => 'aN7ye98FKrmydwfA6tHgHE1PbiidWzUJ9cltnies8F4=',
+              'public_key' => 'hvIyIW2o8JROVKuY2yYFdUn0oA+43aLuT8KCy0YbORE=',
+              'preshared_key' => 'dVW/5kF8wnsx0zAwR4uPIa06btACxpQ/rHBL1B3qPnk=',
+              'enable' => false,
+              'data' => {
+                'cheburek' => 'hah'
+              }
+            },
+            '3' => {
+              'id' => 3,
+              'address' => '10.8.0.4',
+              'private_key' => 'eF3Owsqd5MGAIXjmALGBi8ea8mkFUmAiyh80U3hVXn8=',
+              'public_key' => 'bPKBg66uC1J2hlkE31Of5wnkg+IjowVXgoLcjcLn0js=',
+              'preshared_key' => 'IyVg7fktkSBxJ0uK82j6nlI7Vmo0E53eBmYZ723/45E=',
+              'enable' => true,
+              'data' => {
+                'key' => 'value'
+              }
+            }
+          }
+        }
+      end
+
+      it 'causes an error that the address is already taken' do
+        expect { update_config }.to raise_error(Errors::AddressAlreadyTakenError)
+      end
+    end
   end
 end


### PR DESCRIPTION
When updating a client, if you try to set it to an address that is already used by another client, you will get a 500 server error